### PR TITLE
Issue #25: Issue Delivery Options Sorted Correctly, Default Delivery Frequency Set to Biweekly

### DIFF
--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -21,7 +21,7 @@ class Club < ApplicationRecord
   accepts_nested_attributes_for :members, allow_destroy: true, reject_if: :all_blank
 
   def self.delivery_frequencies
-    { weekly: 7, biweekly: 14, monthly: 28, quarterly: 90, yearly: 365, daily: 1 }
+    { daily: 1, weekly: 7, biweekly: 14, monthly: 28, quarterly: 90, yearly: 365 }
   end
 
   def self.delivery_times

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -21,7 +21,7 @@ class Club < ApplicationRecord
   accepts_nested_attributes_for :members, allow_destroy: true, reject_if: :all_blank
 
   def self.delivery_frequencies
-    { biweekly: 14, weekly: 7, monthly: 28, quarterly: 90, yearly: 365, daily: 1 }
+    { weekly: 7, biweekly: 14, monthly: 28, quarterly: 90, yearly: 365, daily: 1 }
   end
 
   def self.delivery_times
@@ -174,7 +174,7 @@ class Club < ApplicationRecord
 
   def set_defaults
     self.sections ||= Club.sections
-    self.delivery_frequency ||= 7 # weekly
+    self.delivery_frequency ||= 14 # biweekly
     self.delivery_time ||= 8 # 8am
     self.delivery_day ||= 0 # Monday
     self.active ||= true


### PR DESCRIPTION
A quick change. After adjusting, I confirmed functionality by clicking on "Create a New Club" in my local environment. See screenshots for proof-

![Screenshot 2024-10-29 at 7 40 11 PM](https://github.com/user-attachments/assets/c39095d3-d7ae-42b9-84de-a5324dc2e734)
Above image shows default set to Biweekly

![Screenshot 2024-10-29 at 7 40 18 PM](https://github.com/user-attachments/assets/7641f878-ded2-4a8c-8e0d-96739e5417d8)
And here we can see that the Biweekly option is now sitting correctly between Weekly and Monthly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Delivery frequency options now prioritize `weekly` over `biweekly`.
	- Default delivery frequency updated to `biweekly`.

- **Bug Fixes**
	- Validation for `default_number_questions` remains intact, ensuring proper input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->