### PR TITLE
Issue #32: Reduce Comment Display Size

### DIFF
--- a/app/views/answers/_answer.html.erb
+++ b/app/views/answers/_answer.html.erb
@@ -31,7 +31,7 @@
         content: render('comments/form', comment: Comment.new, answer: answer, question: answer.issue_question.prompt, response: answer.content),
         open_on_connect: params[:comment_on] == answer.id.to_s %>
     </div>
-    <div id="comments-<%= answer.id %>" class="<%= comments_hidden %> pl-8 border-l border-gray-200 mt-2 space-y-1.5" data-toggle-class-target="toggleable">
+    <div id="comments-<%= answer.id %>" class="<%= comments_hidden %> ml-2 pl-4 border-l mt-2 space-y-2" data-toggle-class-target="toggleable">
       <%= render answer.comments.order(created_at: :asc) %>
     </div>
   </div>

--- a/app/views/answers/_answer.html.erb
+++ b/app/views/answers/_answer.html.erb
@@ -31,7 +31,7 @@
         content: render('comments/form', comment: Comment.new, answer: answer, question: answer.issue_question.prompt, response: answer.content),
         open_on_connect: params[:comment_on] == answer.id.to_s %>
     </div>
-    <div id="comments-<%= answer.id %>" class="<%= comments_hidden %> pl-4 border-l-2 mt-2 space-y-2" data-toggle-class-target="toggleable">
+    <div id="comments-<%= answer.id %>" class="<%= comments_hidden %> pl-8 border-l border-gray-200 mt-2 space-y-1.5" data-toggle-class-target="toggleable">
       <%= render answer.comments.order(created_at: :asc) %>
     </div>
   </div>

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,9 +1,9 @@
-<div id="<%= dom_id comment %>"class="p-2 bg-gray-50 text-gray-700 rounded <%= params[:comment] == comment.id.to_s ? 'bg-yellow-200' : '' %>">
-  <p class="text-sm flex justify-between">
-    <span class=" font-medium text-gray-500"><%= comment.member.display_name %></span>     
+<div id="<%= dom_id comment %>" class="p-1.5 bg-gray-50 text-gray-700 rounded text-xs <%= params[:comment] == comment.id.to_s ? 'bg-yellow-200' : '' %>">
+  <p class="flex justify-between">
+    <span class="font-medium text-gray-500"><%= comment.member.display_name %></span>     
     <span class="text-gray-300 text-xs ml-2">
       <%= time_ago_in_words(comment.created_at) %> ago
     </span>
   </p>
-    <%= format_and_sanitize_text(comment.content) %>
+  <%= format_and_sanitize_text(comment.content) %>
 </div>


### PR DESCRIPTION
Before:
<img width="807" alt="Screenshot 2024-10-30 at 2 49 08 PM" src="https://github.com/user-attachments/assets/2a490155-9e31-43c1-b4b5-8963692c3b99">

After:
<img width="769" alt="Screenshot 2024-10-30 at 2 48 47 PM" src="https://github.com/user-attachments/assets/61d6302f-c5f0-4305-8972-a9341ecab562">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced styling for the comments section, improving visual spacing and text size.
  
- **Bug Fixes**
	- Adjusted layout of comment content for better presentation without altering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->