### PR TITLE
Issue 33: Upcoming and Sent Colors Differentiate

### DIFF
--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -9,10 +9,15 @@
           'text-[var(--warning-color)]'
         when issue.sent?
           'text-[var(--info-color)]'
+        else
+          'text-gray-500'
         end %>">
-        <%= 'In Progress' if issue.in_progress? %>
-        <%= 'Upcoming' if issue.upcoming? %>
-        <%= 'Sent' if issue.sent? %>
+        <%= case
+          when issue.in_progress? then 'In Progress'
+          when issue.upcoming? then 'Upcoming'
+          when issue.sent? then 'Sent'
+          else 'Unknown'
+        end %>
       </span>
 
 

--- a/app/views/issues/_issue.html.erb
+++ b/app/views/issues/_issue.html.erb
@@ -1,7 +1,15 @@
 <div id="<%= dom_id issue %>" class="frame p-4 pt-2 flex flex-col justify-between gap-4">
   <div>
     <div class="flex justify-between items-end">
-      <span class="text-sm <%= issue.in_progress? ? 'text-[var(--success-color)]' : 'text-[var(--warning-color)]' %>">
+      <span class="text-sm <%= 
+        case
+        when issue.in_progress?
+          'text-[var(--success-color)]'
+        when issue.upcoming?
+          'text-[var(--warning-color)]'
+        when issue.sent?
+          'text-[var(--info-color)]'
+        end %>">
         <%= 'In Progress' if issue.in_progress? %>
         <%= 'Upcoming' if issue.upcoming? %>
         <%= 'Sent' if issue.sent? %>


### PR DESCRIPTION
Updated to pull colors from theme files as following:
- Upcoming: warning color (anticipation/waiting)
- In Progress: success color (active/current)
- Sent: info color (completed/archived)

Before:
<img width="691" alt="Screenshot 2024-10-30 at 3 01 30 PM" src="https://github.com/user-attachments/assets/47890c9e-14d7-4e4d-b6fc-ca04ecb82b94">
<img width="710" alt="Screenshot 2024-10-30 at 3 01 38 PM" src="https://github.com/user-attachments/assets/48eedb39-5da6-4a7c-9e67-2659db9c007a">
<img width="717" alt="Screenshot 2024-10-30 at 3 01 45 PM" src="https://github.com/user-attachments/assets/1c96ccee-141c-4bc5-b9fe-a6902b142117">

After:
<img width="711" alt="Screenshot 2024-10-30 at 3 01 13 PM" src="https://github.com/user-attachments/assets/7ff05c5f-a048-4c2c-9d40-dcad5ca650a3">
<img width="725" alt="Screenshot 2024-10-30 at 3 01 06 PM" src="https://github.com/user-attachments/assets/db38ad7a-2820-4c63-a3ed-a1dc91e7c714">
<img width="721" alt="Screenshot 2024-10-30 at 3 00 59 PM" src="https://github.com/user-attachments/assets/ed471402-fab9-47db-8bfa-70f11b129951">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced status indicator for issues with clearer labels ("In Progress", "Upcoming", "Sent") based on the issue's current state. 
- **Bug Fixes**
	- Improved logic for determining CSS classes for issue statuses, providing better visual clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->