### PR TITLE
Issue 39: Cute Theme Warning Color Fix

### DIFF
--- a/app/assets/stylesheets/themes/cute.css
+++ b/app/assets/stylesheets/themes/cute.css
@@ -5,7 +5,7 @@
     --bg-color: #fff5f5;
     --success-color: #90ee90;
     --danger-color: #ff6347;
-    --warning-color: #ffffe0;
+    --warning-color: #ff6347;
     --info-color: #add8e6;
     --error-color: #ff6347;
     --border-radius: 10px;


### PR DESCRIPTION
Yeah nothing here just changed the warning color to match the danger color, felt like the best option in this not-so-pretty theme.

Before-
<img width="580" alt="Screenshot 2024-10-30 at 3 09 57 PM" src="https://github.com/user-attachments/assets/5ab75aa6-63ca-4a8b-83cb-6646e2adafd1">
<img width="744" alt="Screenshot 2024-10-30 at 3 11 21 PM" src="https://github.com/user-attachments/assets/ea6def69-ad5d-4675-8512-4fe3f2b75f9b">


After-
<img width="674" alt="Screenshot 2024-10-30 at 3 09 42 PM" src="https://github.com/user-attachments/assets/a51a46b9-a600-4aee-bac8-d58c077e3182">
<img width="716" alt="Screenshot 2024-10-30 at 3 09 35 PM" src="https://github.com/user-attachments/assets/765bbcf8-d2a2-4515-bc34-7522be769803">

