### PR TITLE
Issue #34: Better Order Clubs

### DIFF
--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -7,7 +7,8 @@ class ClubsController < ApplicationController
 
   # GET /clubs or /clubs.json
   def index
-    @clubs = authorized_scope(Club.all)
+    @active_clubs = Club.active.order(:title)
+    @inactive_clubs = Club.inactive.order(:title)
   end
 
   # GET /clubs/1 or /clubs/1.json

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -7,7 +7,15 @@ class ClubsController < ApplicationController
 
   # GET /clubs or /clubs.json
   def index
-    @active_clubs = authorized_scope(Club.active.by_next_delivery)
+    @sort = params[:sort] || 'next_delivery'
+    @active_clubs = authorized_scope(Club.active)
+    
+    @active_clubs = case @sort
+      when 'title' then @active_clubs.by_title
+      when 'member_count' then @active_clubs.by_member_count
+      else @active_clubs.by_next_delivery
+    end
+    
     @inactive_clubs = authorized_scope(Club.inactive)
   end
 

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -7,7 +7,7 @@ class ClubsController < ApplicationController
 
   # GET /clubs or /clubs.json
   def index
-    @active_clubs = authorized_scope(Club.active)
+    @active_clubs = authorized_scope(Club.active.by_next_delivery)
     @inactive_clubs = authorized_scope(Club.inactive)
   end
 

--- a/app/controllers/clubs_controller.rb
+++ b/app/controllers/clubs_controller.rb
@@ -7,8 +7,8 @@ class ClubsController < ApplicationController
 
   # GET /clubs or /clubs.json
   def index
-    @active_clubs = Club.active.order(:title)
-    @inactive_clubs = Club.inactive.order(:title)
+    @active_clubs = authorized_scope(Club.active)
+    @inactive_clubs = authorized_scope(Club.inactive)
   end
 
   # GET /clubs/1 or /clubs/1.json

--- a/app/javascript/controllers/disclosure_controller.js
+++ b/app/javascript/controllers/disclosure_controller.js
@@ -1,0 +1,15 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  static targets = ["content", "button", "buttonText", "icon"];
+
+  toggle() {
+    this.contentTarget.classList.toggle("hidden");
+    this.iconTarget.classList.toggle("rotate-180");
+
+    const isHidden = this.contentTarget.classList.contains("hidden");
+    this.buttonTextTarget.textContent = isHidden
+      ? "Show Inactive Clubs"
+      : "Hide Inactive Clubs";
+  }
+}

--- a/app/javascript/controllers/disclosure_controller.js
+++ b/app/javascript/controllers/disclosure_controller.js
@@ -4,7 +4,19 @@ export default class extends Controller {
   static targets = ["content", "button", "buttonText", "icon"];
 
   toggle() {
-    const isHidden = this.contentTarget.classList.toggle("hidden");
-    this.iconTarget.classList.toggle("rotate-180", !isHidden);
+    const content = this.contentTarget;
+    const isExpanded = content.style.height !== "0px";
+    
+    if (!isExpanded) {
+      content.style.height = `${content.scrollHeight}px`;
+    } else {
+      content.style.height = "0px";
+    }
+    
+    this.iconTarget.classList.toggle("rotate-180", !isExpanded);
+  }
+
+  connect() {
+    this.contentTarget.style.height = "0px";
   }
 }

--- a/app/javascript/controllers/disclosure_controller.js
+++ b/app/javascript/controllers/disclosure_controller.js
@@ -4,12 +4,7 @@ export default class extends Controller {
   static targets = ["content", "button", "buttonText", "icon"];
 
   toggle() {
-    this.contentTarget.classList.toggle("hidden");
-    this.iconTarget.classList.toggle("rotate-180");
-
-    const isHidden = this.contentTarget.classList.contains("hidden");
-    this.buttonTextTarget.textContent = isHidden
-      ? "Show Inactive Clubs"
-      : "Hide Inactive Clubs";
+    const isHidden = this.contentTarget.classList.toggle("hidden");
+    this.iconTarget.classList.toggle("rotate-180", !isHidden);
   }
 }

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -29,6 +29,16 @@ class Club < ApplicationRecord
       .order(Arel.sql("MIN(issues.deliver_at) ASC NULLS LAST"))
   }
 
+  scope :by_title, -> { order(title: :asc) }
+
+  scope :by_member_count, -> {
+    joins(:members)
+      .where.not(members: { activated_at: nil })
+      .group(:id)
+      .order(Arel.sql("COUNT(*) ASC"))
+    # I'm not sure why ordering ascending shows them with the most members first.
+  }
+
   def self.delivery_frequencies
     { daily: 1, weekly: 7, biweekly: 14, monthly: 28, quarterly: 90, yearly: 365 }
   end

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -20,6 +20,9 @@ class Club < ApplicationRecord
   after_update :recalculate_issue_dates, if: -> { saved_change_to_delivery_frequency? || saved_change_to_delivery_time? || saved_change_to_delivery_day? || saved_change_to_timezone? }
   accepts_nested_attributes_for :members, allow_destroy: true, reject_if: :all_blank
 
+  scope :active, -> { where(active: true) }
+  scope :inactive, -> { where(active: false) }
+
   def self.delivery_frequencies
     { daily: 1, weekly: 7, biweekly: 14, monthly: 28, quarterly: 90, yearly: 365 }
   end

--- a/app/models/club.rb
+++ b/app/models/club.rb
@@ -22,6 +22,12 @@ class Club < ApplicationRecord
 
   scope :active, -> { where(active: true) }
   scope :inactive, -> { where(active: false) }
+  scope :by_next_delivery, -> {
+    joins("LEFT JOIN issues ON issues.club_id = clubs.id AND issues.sent_at IS NULL")
+      .select("clubs.*, MIN(issues.deliver_at) as next_delivery")
+      .group("clubs.id")
+      .order(Arel.sql("MIN(issues.deliver_at) ASC NULLS LAST"))
+  }
 
   def self.delivery_frequencies
     { daily: 1, weekly: 7, biweekly: 14, monthly: 28, quarterly: 90, yearly: 365 }

--- a/app/views/clubs/_form.html.erb
+++ b/app/views/clubs/_form.html.erb
@@ -36,10 +36,10 @@
 
 
   <div class="mt-6 flex justify-between">
-    <% if @club.persisted? %>
-      <%= button_tag @club.active? ? "Pause Club" : "Activate", 
+    <% if club.persisted? %>
+      <%= button_tag club.active? ? "Pause Club" : "Activate", 
           type: "button", 
-          class: "button outline #{@club.active? ? 'danger' : 'success'}", 
+          class: "button outline #{club.active? ? 'danger' : 'success'}", 
           onclick: "document.querySelector('[data-modal-target=\"toggle-club-status-modal\"]').click()"
          %>
       
@@ -48,41 +48,45 @@
           class: "button minimal danger", 
           onclick: "document.querySelector('[data-modal-target=\"delete-club-modal\"]').click()"
           %>
+    <% else %>
+      <%= form.submit "Create Club", class: "button success" %>
     <% end %>
   </div>
-<% end %>
 
-<%= render 'shared/modal',
-           modal_id: 'delete-club-modal',
-           button_classes: '',
-           button_text: '',
-           title: 'Delete Club',
-           required_input: 'DELETE',
-           required_input_message: 'Type DELETE to confirm',
-           data: { modal_target: "delete-club-modal" },
-           confirm_button: link_to("Delete Club", @club, method: :delete, class: 'button danger', data: { turbo_method: :delete }) do %>
-  <p>Are you sure you want to delete this club?</p>
-  <p class="text-[var(--danger-color)]">This action cannot be undone.</p>
-<% end %>
+  <% if club.persisted? %>
+    <%= render 'shared/modal',
+               modal_id: 'delete-club-modal',
+               button_classes: '',
+               button_text: '',
+               title: 'Delete Club', 
+               required_input: 'DELETE',
+               required_input_message: 'Type DELETE to confirm',
+               data: { modal_target: "delete-club-modal" },
+               confirm_button: link_to("Delete Club", club, method: :delete, class: 'button danger', data: { turbo_method: :delete }) do %>
+      <p>Are you sure you want to delete this club?</p>
+      <p class="text-[var(--danger-color)]">This action cannot be undone.</p>
+    <% end %>
 
-<%= render 'shared/modal',
-           modal_id: 'toggle-club-status-modal',
-           data: { modal_target: "toggle-club-status-modal" },
-           button_classes: 'button minimal',
-           button_text: '',
-           title: @club.active? ? 'Pause Club' : 'Activate Club',
-           confirm_button: button_to(
-             @club.active? ? "Pause Club" : "Activate Club",
-             club_path(@club),
-             method: :patch,
-             class: "button #{@club.active? ? 'warning' : 'success'}",
-             form: { data: { turbo: false } },
-             params: { club: { active: !@club.active } }
-           ) do %>
-  <% if @club.active? %>
-    <p>Are you sure you want to pause this club?</p>
-    <p class="text-[var(--warning-color)]">Current Issues will be deleted and no new issues will be generated while paused.</p>
-  <% else %>
-    <p>Are you sure you want to activate this club? New issues will be generated.</p>
+    <%= render 'shared/modal',
+               modal_id: 'toggle-club-status-modal',
+               data: { modal_target: "toggle-club-status-modal" },
+               button_classes: 'button minimal',
+               button_text: '',
+               title: club.active? ? 'Pause Club' : 'Activate Club',
+               confirm_button: button_to(
+                 club.active? ? "Pause Club" : "Activate Club",
+                 club_path(club),
+                 method: :patch,
+                 class: "button #{club.active? ? 'warning' : 'success'}",
+                 form: { data: { turbo: false } },
+                 params: { club: { active: !club.active } }
+               ) do %>
+      <% if club.active? %>
+        <p>Are you sure you want to pause this club?</p>
+        <p class="text-[var(--warning-color)]">Current Issues will be deleted and no new issues will be generated while paused.</p>
+      <% else %>
+        <p>Are you sure you want to activate this club? New issues will be generated.</p>
+      <% end %>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -1,39 +1,27 @@
-<div class="container mx-auto px-4">
-  <h1 class="text-2xl font-bold mb-6">Clubs</h1>
-
-  <% if @active_clubs.empty? && @inactive_clubs.empty? %>
-    <p class="text-center text-[var(--secondary-color)]">No clubs</p>
-    <p class="text-center">You haven't created any Clubs. Go to
-      <%= link_to 'New Club', new_club_path, class: "font-bold"%> to create one.
-    </p>
-  <% else %>
-    <%# Active Clubs Section %>
-    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
-      <%= render partial: 'club', collection: @active_clubs %>
-    </div>
-
-    <%# Inactive Clubs Section %>
-    <% if @inactive_clubs.any? %>
-      <div data-controller="disclosure">
-        <button
-          data-action="disclosure#toggle"
-          data-disclosure-target="button"
-          class="flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-4"
-        >
-          <span data-disclosure-target="buttonText">Show Inactive Clubs</span>
-          <svg data-disclosure-target="icon" class="w-4 h-4 transform transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-          </svg>
-        </button>
-
-        <div 
-          data-disclosure-target="content"
-          class="hidden grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
-        >
-          <%= render partial: 'club', collection: @inactive_clubs %>
-        </div>
-      </div>
-    <% end %>
+<div class="grid gap-4 md:grid-cols-2 h-full">
+  <%= link_to new_club_path, class: "frame button outline p-4 flex flex-col items-center justify-center" do %>
+    <p class="flex items-center"> <%= icon 'plus', class: 'w-10' %> Create New Club</p>
   <% end %>
+  <%= render @active_clubs %>
 </div>
+
+<% if @inactive_clubs.any? %>
+  <div data-controller="disclosure" class="mt-8">
+    <button data-action="disclosure#toggle" data-disclosure-target="button" class="button minimal">
+      <span data-disclosure-target="buttonText">Show Inactive Clubs</span>
+    </button>
+    <div data-disclosure-target="content" class="hidden">
+      <div class="grid gap-4 md:grid-cols-2 h-full mt-4">
+        <%= render @inactive_clubs %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<% if @active_clubs.empty? && @inactive_clubs.empty? %>
+  <p class="text-center text-[var(--secondary-color)]">No clubs</p>
+  <p class="text-center">You haven't created any Clubs. Go to
+    <%= link_to 'New Club', new_club_path, class: "font-bold"%> to create one.
+  </p>
+<% end %>
 

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -7,8 +7,11 @@
 
 <% if @inactive_clubs.any? %>
   <div data-controller="disclosure" class="mt-8">
-    <button data-action="disclosure#toggle" data-disclosure-target="button" class="button minimal">
-      <span data-disclosure-target="buttonText">Show Inactive Clubs</span>
+    <button data-action="disclosure#toggle" data-disclosure-target="button" class="flex items-center gap-2 text-gray-600 hover:text-gray-900">
+      <span data-disclosure-target="buttonText">Inactive Clubs</span>
+      <svg data-disclosure-target="icon" class="w-4 h-4 transform transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+      </svg>
     </button>
     <div data-disclosure-target="content" class="hidden">
       <div class="grid gap-4 md:grid-cols-2 h-full mt-4">

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -1,14 +1,39 @@
-<div class="grid gap-4 md:grid-cols-2 h-full">
-   <%= link_to new_club_path, class: "frame button outline p-4 flex flex-col items-center justify-center" do %>
-    <p class="flex items-center"> <%= icon 'plus', class: 'w-10' %> Create New Club</p>
-  <% end %>
-  <%= render @clubs %>
-</div>
+<div class="container mx-auto px-4">
+  <h1 class="text-2xl font-bold mb-6">Clubs</h1>
 
-<% if @clubs.empty?%>
-  <p class="text-center text-[var(--secondary-color)]">No clubs</p>
+  <% if @active_clubs.empty? && @inactive_clubs.empty? %>
+    <p class="text-center text-[var(--secondary-color)]">No clubs</p>
     <p class="text-center">You haven't created any Clubs. Go to
       <%= link_to 'New Club', new_club_path, class: "font-bold"%> to create one.
     </p>
-<% end %>
+  <% else %>
+    <%# Active Clubs Section %>
+    <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
+      <%= render partial: 'club', collection: @active_clubs %>
+    </div>
+
+    <%# Inactive Clubs Section %>
+    <% if @inactive_clubs.any? %>
+      <div data-controller="disclosure">
+        <button
+          data-action="disclosure#toggle"
+          data-disclosure-target="button"
+          class="flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-4"
+        >
+          <span data-disclosure-target="buttonText">Show Inactive Clubs</span>
+          <svg data-disclosure-target="icon" class="w-4 h-4 transform transition-transform duration-200" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+
+        <div 
+          data-disclosure-target="content"
+          class="hidden grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4"
+        >
+          <%= render partial: 'club', collection: @inactive_clubs %>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>
 

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -13,8 +13,10 @@
         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
       </svg>
     </button>
-    <div data-disclosure-target="content" class="hidden">
-      <div class="grid gap-4 md:grid-cols-2 h-full mt-4">
+    <div data-disclosure-target="content" 
+         class="transform transition-all duration-300 ease-in-out overflow-hidden"
+         style="height: 0">
+      <div class="grid gap-4 md:grid-cols-2 h-full mt-4 pb-4">
         <%= render @inactive_clubs %>
       </div>
     </div>

--- a/app/views/clubs/index.html.erb
+++ b/app/views/clubs/index.html.erb
@@ -1,3 +1,13 @@
+<div class="mb-4 flex justify-end gap-2">
+  <span class="text-sm text-gray-500">Sort by:</span>
+  <%= link_to "Next Delivery", clubs_path(sort: 'next_delivery'), 
+      class: "text-sm #{@sort == 'next_delivery' ? 'font-bold' : 'text-gray-500'}" %>
+  <%= link_to "Title", clubs_path(sort: 'title'), 
+      class: "text-sm #{@sort == 'title' ? 'font-bold' : 'text-gray-500'}" %>
+  <%= link_to "Member Count", clubs_path(sort: 'member_count'), 
+      class: "text-sm #{@sort == 'member_count' ? 'font-bold' : 'text-gray-500'}" %>
+</div>
+
 <div class="grid gap-4 md:grid-cols-2 h-full">
   <%= link_to new_club_path, class: "frame button outline p-4 flex flex-col items-center justify-center" do %>
     <p class="flex items-center"> <%= icon 'plus', class: 'w-10' %> Create New Club</p>


### PR DESCRIPTION
This one was harder than anticipated.

Total changes:
- separates active from inactive clubs
- sorts active clubs (default by Next Delivery)

Proof....

Only active clubs displayed, dropdown for inactive clubs-
![Screenshot 2024-10-30 at 10 27 00 PM](https://github.com/user-attachments/assets/ea54043e-5e99-411b-8e5a-136a4f4de92c)

Inactive clubs get displayed with a really nice wipe animation-
![Screenshot 2024-10-30 at 10 27 06 PM](https://github.com/user-attachments/assets/4636e2d8-d953-4008-9e18-d517ecdfdb48)

If I activate all clubs, we can see the sorting:
Next Delivery-
![Screenshot 2024-10-30 at 10 26 27 PM](https://github.com/user-attachments/assets/0d4eeafd-6ece-49ec-8106-5e4bc911174f)

Title-
![Screenshot 2024-10-30 at 10 26 32 PM](https://github.com/user-attachments/assets/b520336b-b0b4-4b4a-a53e-dfaf548e3cb5)

Member count-
![Screenshot 2024-10-30 at 10 26 36 PM](https://github.com/user-attachments/assets/a04e18f4-6acf-4948-89af-1752d65a069c)
(Note: for some reason I had to query these by number of members in ascending order for it to display in descending order. Which OK maybe we're displaying clubs bottom->up, but the other two sorting methods work just fine. Poked around a bunch to figure this out. No clue why it's like this.)

